### PR TITLE
Add support for values without decimal part

### DIFF
--- a/lib/triangular/point.rb
+++ b/lib/triangular/point.rb
@@ -33,7 +33,7 @@ module Triangular
     end
 
     def self.pattern
-      /(?<x>-?\d+.\d+(e-?\d+)?)\s(?<y>-?\d+.\d+(e-?\d+)?)\s(?<z>-?\d+.\d+(e-?\d+)?)/
+      /(?<x>-?\d+(.\d+(e-?\d+)?)?)\s(?<y>-?\d+(.\d+(e-?\d+)?)?)\s(?<z>-?\d+(.\d+(e-?\d+)?)?)/
     end
   end
 end

--- a/spec/triangular/facet_spec.rb
+++ b/spec/triangular/facet_spec.rb
@@ -60,62 +60,6 @@ describe Triangular::Facet do
       end
     end
 
-    context "with values without decimal parts" do
-      before :each do
-        @result = Triangular::Facet.parse(<<-FACET)
-          facet normal 0 0 -1
-            outer loop
-              vertex 16.5 0 -0.75
-              vertex 0 -9.5 -0.75
-              vertex 0 0 -0.75
-            endloop
-          endfacet
-        FACET
-      end
-
-      it 'should return a facet object' do
-        expect(@result).to be_a Triangular::Facet
-      end
-
-      it 'should return a facet with 3 vertices' do
-        expect(@result.vertices.length).to eq(3)
-      end
-
-      it 'should return a facet with vertices of type Vertex' do
-        @result.vertices.each do |vertex|
-          expect(vertex).to be_a Triangular::Vertex
-        end
-      end
-
-      it 'should return a facet with a normal of type Vector' do
-        expect(@result.normal).to be_a Triangular::Vector
-      end
-
-      it 'should correctly set the normal values' do
-        expect(@result.normal.x).to eq(0)
-        expect(@result.normal.y).to eq(0)
-        expect(@result.normal.z).to eq(-1)
-      end
-
-      it 'should correctly set the values for the first vertex' do
-        expect(@result.vertices[0].x).to eq(16.5)
-        expect(@result.vertices[0].y).to eq(0)
-        expect(@result.vertices[0].z).to eq(-0.75)
-      end
-
-      it 'should correctly set the values for the second vertex' do
-        expect(@result.vertices[1].x).to eq(0)
-        expect(@result.vertices[1].y).to eq(-9.5)
-        expect(@result.vertices[1].z).to eq(-0.75)
-      end
-
-      it 'should correctly set the values for the third vertex' do
-        expect(@result.vertices[2].x).to eq(0)
-        expect(@result.vertices[2].y).to eq(0)
-        expect(@result.vertices[2].z).to eq(-0.75)
-      end
-    end
-
     context 'when passed multiple facets' do
       before do
         @result = Triangular::Facet.parse(<<-FACET)

--- a/spec/triangular/facet_spec.rb
+++ b/spec/triangular/facet_spec.rb
@@ -60,6 +60,62 @@ describe Triangular::Facet do
       end
     end
 
+    context "with values without decimal parts" do
+      before :each do
+        @result = Triangular::Facet.parse(<<-FACET)
+          facet normal 0 0 -1
+            outer loop
+              vertex 16.5 0 -0.75
+              vertex 0 -9.5 -0.75
+              vertex 0 0 -0.75
+            endloop
+          endfacet
+        FACET
+      end
+
+      it 'should return a facet object' do
+        expect(@result).to be_a Triangular::Facet
+      end
+
+      it 'should return a facet with 3 vertices' do
+        expect(@result.vertices.length).to eq(3)
+      end
+
+      it 'should return a facet with vertices of type Vertex' do
+        @result.vertices.each do |vertex|
+          expect(vertex).to be_a Triangular::Vertex
+        end
+      end
+
+      it 'should return a facet with a normal of type Vector' do
+        expect(@result.normal).to be_a Triangular::Vector
+      end
+
+      it 'should correctly set the normal values' do
+        expect(@result.normal.x).to eq(0)
+        expect(@result.normal.y).to eq(0)
+        expect(@result.normal.z).to eq(-1)
+      end
+
+      it 'should correctly set the values for the first vertex' do
+        expect(@result.vertices[0].x).to eq(16.5)
+        expect(@result.vertices[0].y).to eq(0)
+        expect(@result.vertices[0].z).to eq(-0.75)
+      end
+
+      it 'should correctly set the values for the second vertex' do
+        expect(@result.vertices[1].x).to eq(0)
+        expect(@result.vertices[1].y).to eq(-9.5)
+        expect(@result.vertices[1].z).to eq(-0.75)
+      end
+
+      it 'should correctly set the values for the third vertex' do
+        expect(@result.vertices[2].x).to eq(0)
+        expect(@result.vertices[2].y).to eq(0)
+        expect(@result.vertices[2].z).to eq(-0.75)
+      end
+    end
+
     context 'when passed multiple facets' do
       before do
         @result = Triangular::Facet.parse(<<-FACET)

--- a/spec/triangular/point_spec.rb
+++ b/spec/triangular/point_spec.rb
@@ -43,6 +43,24 @@ describe Triangular::Point do
         expect(@result.z).to eq(5.23431439438796e32)
       end
     end
+
+    context 'with a point with no fractional part' do
+      before do
+        @result = Triangular::Point.parse('  -5 0 5 ')
+      end
+
+      it 'should correctly set the X value' do
+        expect(@result.x).to eq(-5.0)
+      end
+
+      it 'should correctly set the Y value' do
+        expect(@result.y).to eq(0.0)
+      end
+
+      it 'should correctly set the Z value' do
+        expect(@result.z).to eq(5.0)
+      end
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
Hello there!

Sometime tools like OpenSCAD output a STL file with no decimal parts on their point values, for example:

```
          facet normal 0 0 -1
            outer loop
              vertex 16.5 0 -0.75
              vertex 0 -9.5 -0.75
              vertex 0 0 -0.75
            endloop
          endfacet
```

There is a bug report open on OpenSCAD https://github.com/openscad/openscad/issues/2651 but there seems to a debate about whether or not it should be fixed (I haven't read through the whole thing to be honest :c).

In any case, I propose here some changes to the Point pattern so it can support numbers without decimal parts.

Have a great day and thank you for your work!
